### PR TITLE
Add filters and submenuIndex parameters to URL Generation

### DIFF
--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -161,6 +161,14 @@ final class ActionFactory
             $requestParameters[EA::ENTITY_ID] = $entityDto->getPrimaryKeyValueAsString();
         }
 
+        if ($request->query->has(EA::FILTERS)) {
+            $requestParameters[EA::FILTERS] = $request->get(EA::FILTERS);
+        }
+
+        if ($request->query->has(EA::SUBMENU_INDEX)) {
+            $requestParameters[EA::SUBMENU_INDEX] = $request->get(EA::SUBMENU_INDEX);
+        }
+
         return $this->adminUrlGenerator->unsetAllExcept(EA::MENU_INDEX, EA::SUBMENU_INDEX)->setAll($requestParameters)->generateUrl();
     }
 


### PR DESCRIPTION
Add the filters (EA::FILTERS) and submenuIndex (EA::SUBMENU_INDEX) parameters to the generated URL, but only when they are present in the current request.

This will keep the filters and submenuIndex value in all generated links of the specific CRUD.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
